### PR TITLE
Build against 2019-09, fix build error due to missing S20190521195709 repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
     <tycho-extras-version>${tycho-version}</tycho-extras-version>
 
     <!-- eclipse version m2e is built against -->
-    <eclipse.stream>2019-06</eclipse.stream>
-    <eclipse-repo.url>http://download.eclipse.org/eclipse/updates/4.12/</eclipse-repo.url>
+    <eclipse.stream>2019-09</eclipse.stream>
+    <eclipse-repo.url>http://download.eclipse.org/eclipse/updates/4.13/</eclipse-repo.url>
     <eclipse-simrel.url>http://download.eclipse.org/releases/${eclipse.stream}</eclipse-simrel.url>
 
     <tycho.testArgLine>-Xmx800m</tycho.testArgLine>
@@ -79,9 +79,9 @@
       <url>http://download.eclipse.org/cbi/updates/license</url>
     </repository>
     <repository>
-      <id>Orbit 2019-06 M3</id>
+      <id>Orbit 2019-09</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/tools/orbit/downloads/drops/S20190521195709/repository/</url>
+      <url>https://download.eclipse.org/tools/orbit/downloads/drops/R20190827152740/repository/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Fixes build error:
```
[...]
Caused by: org.eclipse.equinox.p2.core.ProvisionException: No repository found at https://download.eclipse.org/tools/orbit/downloads/drops/S20190521195709/repository.
    at org.eclipse.equinox.internal.p2.repository.helpers.AbstractRepositoryManager.fail (AbstractRepositoryManager.java:398)
    at org.eclipse.equinox.internal.p2.repository.helpers.AbstractRepositoryManager.loadRepository (AbstractRepositoryManager.java:695)
    [...]
```
S20190521195709 (2019-06 M3) repo seems to have vanished, most likely because 2019-06 has long been released.